### PR TITLE
Indicate perk picks which would trigger Perks Lottery

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,6 +1,9 @@
 .fungal-shift:nth-child(even) {
   background-color: hsla(var(--b2)/var(--tw-bg-opacity,1));
 }
+.perk {
+  position: relative;
+}
 .perk > img {
   image-rendering: pixelated;
   image-rendering: -moz-crisp-edges;
@@ -11,6 +14,12 @@
 .perk-gambled {
   background-color: hsla(var(--wa)/var(--tw-bg-opacity,1));
   cursor: default;
+}
+.perk-preserved:before {
+  content: "🍀";
+  position: absolute;
+  top: 0;
+  right: 0;
 }
 .perk-reroll {
   background: url('img/perk_reroll.png') center -17px/contain no-repeat;

--- a/index.html
+++ b/index.html
@@ -249,8 +249,16 @@
               <button class="btn btn-sm w-4 block" @click="perksGoEast">&gt;</button>
             </div>
             <div class="flex flex-row justify-between items-center" v-for="(perkList, level) in seedInfo.perks">
-              <div v-for="(perk, index) in perkList" :title="perk.ui_name" :class="['cursor-pointer', 'perk', pickedPerks[perkWorldOffset]?.[level] === perk.id ? 'perk-active' : '', perk.gambled ? 'perk-gambled' : '']" @click="onClickPerk(level, perk)">
-                <img :src="'data:image/png;base64,' + perk.ui_icon" class="w-16 h-16">
+              <div v-for="(info, index) in perkList" :title="info.perk.ui_name" :class="[
+                  'cursor-pointer',
+                  'perk',
+                  pickedPerks[perkWorldOffset]?.[level] === info.perk.id ? 'perk-active' : '',
+                  (pickedPerks.flat().find(id => id === 'PERKS_LOTTERY') || info.perk.id === 'PERKS_LOTTERY') && info.willBeRemoved === false ? 'perk-preserved' : '',
+                  info.gambled ? 'perk-gambled' : '',
+                ]"
+                @click="onClickPerk(level, info.perk)"
+              >
+                <img :src="'data:image/png;base64,' + info.perk.ui_icon" class="w-16 h-16">
               </div>
               <div class="btn btn-ghost w-16 h-16" title="Reroll: right-click to unroll" @click="increasePerkRerolls(level)" @contextmenu.prevent="decreasePerkRerolls(level)">
                 <div class="perk-reroll text-right w-full h-full">

--- a/index.js
+++ b/index.js
@@ -124,11 +124,11 @@ app = new Vue({
     },
     perksGoEast() {
       this.perkWorldOffset++;
-      this.seedInfo.perks = infoProviders.PERK.provide(this.pickedPerks, null, true, this.perkWorldOffset, this.perkRerolls);
+      this.seedInfo.perks = infoProviders.PERK.provide(this.pickedPerks, null, this.perkWorldOffset, this.perkRerolls);
     },
     perksGoWest() {
       this.perkWorldOffset--;
-      this.seedInfo.perks = infoProviders.PERK.provide(this.pickedPerks, null, true, this.perkWorldOffset, this.perkRerolls);
+      this.seedInfo.perks = infoProviders.PERK.provide(this.pickedPerks, null, this.perkWorldOffset, this.perkRerolls);
     },
     onClickPerk(level, perk) {
       if (perk.gambled) return;
@@ -143,7 +143,7 @@ app = new Vue({
       let changed;
       do {
         changed = false;
-        this.seedInfo.perks = infoProviders.PERK.provide(this.pickedPerks, null, true, this.perkWorldOffset, this.perkRerolls);
+        this.seedInfo.perks = infoProviders.PERK.provide(this.pickedPerks, null, this.perkWorldOffset, this.perkRerolls);
         for (let i = 0; i < this.pickedPerks[this.perkWorldOffset].length; i++) {
           if (this.pickedPerks[this.perkWorldOffset][i] && !this.seedInfo.perks[i].some(e => e.perk.id === this.pickedPerks[this.perkWorldOffset][i])) {
             delete this.pickedPerks[this.perkWorldOffset][i];
@@ -232,7 +232,7 @@ app = new Vue({
         startingFlask: infoProviders.STARTING_FLASK.provide(),
         startingSpell: infoProviders.STARTING_SPELL.provide(),
         startingBombSpell: infoProviders.STARTING_BOMB_SPELL.provide(),
-        perks: infoProviders.PERK.provide(this.pickedPerks, null, true, this.perkWorldOffset, this.perkRerolls),
+        perks: infoProviders.PERK.provide(this.pickedPerks, null, this.perkWorldOffset, this.perkRerolls),
         perkDeck: infoProviders.PERK.getPerkDeck(true),
         fungalShifts: infoProviders.FUNGAL_SHIFT.provide(null, this.fungalHoldingFlasks),
         biomeModifiers: infoProviders.BIOME_MODIFIER.provide()

--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ app = new Vue({
         changed = false;
         this.seedInfo.perks = infoProviders.PERK.provide(this.pickedPerks, null, true, this.perkWorldOffset, this.perkRerolls);
         for (let i = 0; i < this.pickedPerks[this.perkWorldOffset].length; i++) {
-          if (this.pickedPerks[this.perkWorldOffset][i] && !this.seedInfo.perks[i].some(e => e.id === this.pickedPerks[this.perkWorldOffset][i])) {
+          if (this.pickedPerks[this.perkWorldOffset][i] && !this.seedInfo.perks[i].some(e => e.perk.id === this.pickedPerks[this.perkWorldOffset][i])) {
             delete this.pickedPerks[this.perkWorldOffset][i];
             changed = true;
             break;

--- a/requirements.js
+++ b/requirements.js
@@ -440,8 +440,7 @@ class PerkInfoProvider extends InfoProvider {
     }
     return result;
   }
-  provide(perkPicks, maxLevels, returnPerkObjects, worldOffset, rerolls) {
-    if (returnPerkObjects !== true) throw "assertion fail"
+  provide(perkPicks, maxLevels, worldOffset, rerolls) {
     let getPerks = (perkPicks, maxLevels, worldOffset) => {
       perkPicks = perkPicks || [];
       worldOffset = worldOffset || 0;
@@ -914,11 +913,11 @@ class SeedRequirementPerk extends SeedRequirement {
     let perks = this.provider.provide(null, level);
     if (level == -1) {
       for (let i = 0; i < perks.length; i++) {
-        if (perks[i].indexOf(perk) !== -1) return true;
+        if (perks[i].findIndex(e => e.perk.id === perk) !== -1) return true;
       }
       return false;
     }
-    return perks[level - 1].indexOf(perk) !== -1;
+    return perks[level - 1].findIndex(e => e.perk.id === perk) !== -1;
   }
 }
 


### PR DESCRIPTION
If Perks Lottery has been taken (or for the Perks Lottery perk choice itself) and taking a perk would not cause the other perk options to be removed, then a clover badge will be displayed.

Note this changes the results of `PerkInfoProvider.provide()` to be data objects containing the `perk_id`, `perk`, `gambled`, and `willBeRemoved` properties, instead of just the perk objects.

NOTE: This does not update the trigger chance with taken lottery perks, as a player may want to know if they should skip early perk choices and backtrack once lottery has been taken to get more value.

Example seeds to check:

* `1496135751` – Lottery perk is not lucky, but after it’s selected previous lucky perks are flagged
* `1496135767` – Initial Lottery perk pick is visible as lucky