### PR TITLE
Refactor the perk lottery checks

### DIFF
--- a/index.html
+++ b/index.html
@@ -263,7 +263,7 @@
                 class="cursor-pointer perk"
                 :class="{
                   'perk-active': pickedPerks[perkWorldOffset]?.[level]?.some(e => e === info.perk.id),
-                  'perk-preserved': !info.gambled && info.willBeRemoved === false,
+                  'perk-preserved': !info.gambled && seedInfo.perksLottery[level][index] === false,
                   'perk-gambled': info.gambled,
                 }"
                 @click="onClickPerk(level, info.perk)"

--- a/index.js
+++ b/index.js
@@ -247,7 +247,7 @@ app = new Vue({
         startingBombSpell: infoProviders.STARTING_BOMB_SPELL.provide(),
         perkDeck: infoProviders.PERK.getPerkDeck(true),
         perks: null,
-        perkLottery: null,
+        perksLottery: null,
         fungalShifts: infoProviders.FUNGAL_SHIFT.provide(null),
         biomeModifiers: infoProviders.BIOME_MODIFIER.provide(),
         waterCave: infoProviders.WATER_CAVE.provide(),

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ app = new Vue({
       startingFlask: null,
       startingBombWand: null,
       perks: null,
+      perkLottery: null,
       fungalShifts: null
     },
 
@@ -173,6 +174,7 @@ app = new Vue({
     },
     refreshPerks() {
       this.seedInfo.perks = infoProviders.PERK.provide(this.pickedPerks, null, this.perkWorldOffset, this.perkRerolls);
+      this.seedInfo.perksLottery = infoProviders.PERK.perkLottery(this.pickedPerks, this.seedInfo.perks, this.perkWorldOffset);
     },
     copyString(str) {
       let txtCopy = document.createElement('input');
@@ -235,18 +237,22 @@ app = new Vue({
           rainType: [false]
         };
       }
+
       SetWorldSeed(Number(this.seed));
+
       this.seedInfo = {
         rainType: infoProviders.RAIN.provide(),
         startingFlask: infoProviders.STARTING_FLASK.provide(),
         startingSpell: infoProviders.STARTING_SPELL.provide(),
         startingBombSpell: infoProviders.STARTING_BOMB_SPELL.provide(),
-        perks: infoProviders.PERK.provide(this.pickedPerks, null, this.perkWorldOffset, this.perkRerolls),
         perkDeck: infoProviders.PERK.getPerkDeck(true),
+        perks: null,
+        perkLottery: null,
         fungalShifts: infoProviders.FUNGAL_SHIFT.provide(null),
         biomeModifiers: infoProviders.BIOME_MODIFIER.provide(),
         waterCave: infoProviders.WATER_CAVE.provide(),
       };
+      this.refreshPerks();
     },
   },
   computed: {


### PR DESCRIPTION
This is now done as a separate step after the perks have been calculated, which allows two things to be fixed:

* Rerolling into a lottery perk would not correctly flag it (visible in seed 1600042, when rerolling the first row)
* It wasn’t possible to properly factor in the lottery perks themselves

This also fixes gambling into a lottery perk.