### PR TITLE
Color links, so they're identifiable without hovering all text

### DIFF
--- a/index.css
+++ b/index.css
@@ -56,6 +56,9 @@
   height: 256px;
   background: url('img/darkcaves.png') 0 0 / 100% no-repeat;
 }
+.link {
+  color: #6495ED;
+}
 @media (max-width: 768px) {
   .seed-criteria {
     display: block;


### PR DESCRIPTION
A suggestion! Many people don't recognize that "Show deck" is a link. This should fix that problem.